### PR TITLE
Improves the fluent API in Column and Document in the condition

### DIFF
--- a/diana-column/src/main/java/org/jnosql/diana/api/column/query/ColumnDeleteFrom.java
+++ b/diana-column/src/main/java/org/jnosql/diana/api/column/query/ColumnDeleteFrom.java
@@ -41,7 +41,7 @@ public interface ColumnDeleteFrom {
      * Starts a new condition defining the  column name
      *
      * @param name the column name
-     * @return a new {@link ColumnWhereName}
+     * @return a new {@link ColumnDeleteWhereName}
      * @throws NullPointerException when name is null
      */
     ColumnDeleteWhereName where(String name) throws NullPointerException;

--- a/diana-column/src/main/java/org/jnosql/diana/api/column/query/ColumnDeleteWhereName.java
+++ b/diana-column/src/main/java/org/jnosql/diana/api/column/query/ColumnDeleteWhereName.java
@@ -24,7 +24,7 @@ public interface ColumnDeleteWhereName extends ColumnDeleteNameCondition {
     /**
      * Creates the equals condition {@link org.jnosql.diana.api.Condition#NOT}
      *
-     * @return {@link ColumnNotCondition}
+     * @return {@link ColumnDeleteNotCondition}
      */
     ColumnDeleteNotCondition not();
 }

--- a/diana-column/src/main/java/org/jnosql/diana/api/column/query/ColumnDeleteWhereName.java
+++ b/diana-column/src/main/java/org/jnosql/diana/api/column/query/ColumnDeleteWhereName.java
@@ -16,6 +16,9 @@
  */
 package org.jnosql.diana.api.column.query;
 
+/**
+ * Starts the where name condition on delete query
+ */
 public interface ColumnDeleteWhereName extends ColumnDeleteNameCondition {
 
     /**

--- a/diana-column/src/main/java/org/jnosql/diana/api/column/query/DefaultSelectQueryBuilder.java
+++ b/diana-column/src/main/java/org/jnosql/diana/api/column/query/DefaultSelectQueryBuilder.java
@@ -193,6 +193,12 @@ class DefaultSelectQueryBuilder implements ColumnSelect, ColumnFrom, ColumnWhere
         return this;
     }
 
+
+    @Override
+    public ColumnQuery build() {
+        return new DefaultColumnQuery(limit, start, columnFamily, columns, sorts, condition);
+    }
+
     private ColumnWhere appendCondition(ColumnCondition newCondition) {
         if (negate) {
             newCondition = newCondition.negate();
@@ -209,11 +215,5 @@ class DefaultSelectQueryBuilder implements ColumnSelect, ColumnFrom, ColumnWhere
         this.negate = false;
         this.name = null;
         return this;
-    }
-
-
-    @Override
-    public ColumnQuery build() {
-        return new DefaultColumnQuery(limit, start, columnFamily, columns, sorts, condition);
     }
 }

--- a/diana-column/src/test/java/org/jnosql/diana/api/column/query/DefaultDeleteQueryBuilderTest.java
+++ b/diana-column/src/test/java/org/jnosql/diana/api/column/query/DefaultDeleteQueryBuilderTest.java
@@ -125,13 +125,13 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").eq(name).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.EQUALS, columnCondition.getCondition());
+        assertEquals(Condition.EQUALS, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(name, column.get());
 
@@ -142,13 +142,13 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").like(name).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.LIKE, columnCondition.getCondition());
+        assertEquals(Condition.LIKE, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(name, column.get());
     }
@@ -158,13 +158,13 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         Number value = 10;
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").gt(value).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.GREATER_THAN, columnCondition.getCondition());
+        assertEquals(Condition.GREATER_THAN, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(value, column.get());
     }
@@ -174,13 +174,13 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         Number value = 10;
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").gte(value).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.GREATER_EQUALS_THAN, columnCondition.getCondition());
+        assertEquals(Condition.GREATER_EQUALS_THAN, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(value, column.get());
     }
@@ -223,13 +223,13 @@ public class DefaultDeleteQueryBuilderTest {
         Number valueA = 10;
         Number valueB = 20;
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").between(valueA, valueB).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.BETWEEN, columnCondition.getCondition());
+        assertEquals(Condition.BETWEEN, condition.getCondition());
         assertEquals("name", column.getName());
         Assert.assertThat(column.get(new TypeReference<List<Number>>() {
         }), Matchers.contains(10, 20));
@@ -240,13 +240,13 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").not().eq(name).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         ColumnCondition negate = column.get(ColumnCondition.class);
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.NOT, columnCondition.getCondition());
+        assertEquals(Condition.NOT, condition.getCondition());
         assertEquals(Condition.EQUALS, negate.getCondition());
         assertEquals("name", negate.getColumn().getName());
         assertEquals(name, negate.getColumn().get());
@@ -258,12 +258,12 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").eq(name).and("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.AND, columnCondition.getCondition());
+        assertEquals(Condition.AND, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -273,12 +273,12 @@ public class DefaultDeleteQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").eq(name).or("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.OR, columnCondition.getCondition());
+        assertEquals(Condition.OR, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -291,12 +291,12 @@ public class DefaultDeleteQueryBuilderTest {
 
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").eq(name)
                 .and(ColumnCondition.gt(Column.of("age", 10))).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.AND, columnCondition.getCondition());
+        assertEquals(Condition.AND, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -307,12 +307,12 @@ public class DefaultDeleteQueryBuilderTest {
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where("name").eq(name)
                 .or(ColumnCondition.gt(Column.of("age", 10))).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.OR, columnCondition.getCondition());
+        assertEquals(Condition.OR, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -325,12 +325,12 @@ public class DefaultDeleteQueryBuilderTest {
 
         ColumnDeleteQuery query = delete().from(columnFamily).where(ColumnCondition.eq(Column.of("name", name))
         ).and("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.AND, columnCondition.getCondition());
+        assertEquals(Condition.AND, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -341,12 +341,12 @@ public class DefaultDeleteQueryBuilderTest {
         String name = "Ada Lovelace";
         ColumnDeleteQuery query = delete().from(columnFamily).where(ColumnCondition.eq(Column.of("name", name)))
                 .or("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.OR, columnCondition.getCondition());
+        assertEquals(Condition.OR, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }

--- a/diana-column/src/test/java/org/jnosql/diana/api/column/query/DefaultSelectQueryBuilderTest.java
+++ b/diana-column/src/test/java/org/jnosql/diana/api/column/query/DefaultSelectQueryBuilderTest.java
@@ -162,13 +162,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where("name").eq(name).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.EQUALS, columnCondition.getCondition());
+        assertEquals(Condition.EQUALS, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(name, column.get());
 
@@ -179,13 +179,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where("name").like(name).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.LIKE, columnCondition.getCondition());
+        assertEquals(Condition.LIKE, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(name, column.get());
     }
@@ -195,13 +195,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         Number value = 10;
         ColumnQuery query = select().from(columnFamily).where("name").gt(value).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.GREATER_THAN, columnCondition.getCondition());
+        assertEquals(Condition.GREATER_THAN, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(value, column.get());
     }
@@ -211,13 +211,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         Number value = 10;
         ColumnQuery query = select().from(columnFamily).where("name").gte(value).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.GREATER_EQUALS_THAN, columnCondition.getCondition());
+        assertEquals(Condition.GREATER_EQUALS_THAN, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(value, column.get());
     }
@@ -227,13 +227,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         Number value = 10;
         ColumnQuery query = select().from(columnFamily).where("name").lt(value).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.LESSER_THAN, columnCondition.getCondition());
+        assertEquals(Condition.LESSER_THAN, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(value, column.get());
     }
@@ -243,13 +243,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         Number value = 10;
         ColumnQuery query = select().from(columnFamily).where("name").lte(value).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.LESSER_EQUALS_THAN, columnCondition.getCondition());
+        assertEquals(Condition.LESSER_EQUALS_THAN, condition.getCondition());
         assertEquals("name", column.getName());
         assertEquals(value, column.get());
     }
@@ -260,13 +260,13 @@ public class DefaultSelectQueryBuilderTest {
         Number valueA = 10;
         Number valueB = 20;
         ColumnQuery query = select().from(columnFamily).where("name").between(valueA, valueB).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
 
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.BETWEEN, columnCondition.getCondition());
+        assertEquals(Condition.BETWEEN, condition.getCondition());
         assertEquals("name", column.getName());
         Assert.assertThat(column.get(new TypeReference<List<Number>>() {}), Matchers.contains(10, 20));
     }
@@ -276,13 +276,13 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where("name").not().eq(name).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         ColumnCondition negate = column.get(ColumnCondition.class);
         assertTrue(query.getColumns().isEmpty());
         assertEquals(columnFamily, query.getColumnFamily());
-        assertEquals(Condition.NOT, columnCondition.getCondition());
+        assertEquals(Condition.NOT, condition.getCondition());
         assertEquals(Condition.EQUALS, negate.getCondition());
         assertEquals("name", negate.getColumn().getName());
         assertEquals(name, negate.getColumn().get());
@@ -294,12 +294,12 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where("name").eq(name).and("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.AND, columnCondition.getCondition());
+        assertEquals(Condition.AND, condition.getCondition());
       assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
               ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -309,12 +309,12 @@ public class DefaultSelectQueryBuilderTest {
         String columnFamily = "columnFamily";
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where("name").eq(name).or("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.OR, columnCondition.getCondition());
+        assertEquals(Condition.OR, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -327,12 +327,12 @@ public class DefaultSelectQueryBuilderTest {
 
         ColumnQuery query = select().from(columnFamily).where("name").eq(name)
                 .and(ColumnCondition.gt(Column.of("age", 10))).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.AND, columnCondition.getCondition());
+        assertEquals(Condition.AND, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -343,12 +343,12 @@ public class DefaultSelectQueryBuilderTest {
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where("name").eq(name)
                 .or(ColumnCondition.gt(Column.of("age", 10))).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.OR, columnCondition.getCondition());
+        assertEquals(Condition.OR, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -361,12 +361,12 @@ public class DefaultSelectQueryBuilderTest {
 
         ColumnQuery query = select().from(columnFamily).where(ColumnCondition.eq(Column.of("name", name))
         ).and("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.AND, columnCondition.getCondition());
+        assertEquals(Condition.AND, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }
@@ -377,12 +377,12 @@ public class DefaultSelectQueryBuilderTest {
         String name = "Ada Lovelace";
         ColumnQuery query = select().from(columnFamily).where(ColumnCondition.eq(Column.of("name", name)))
                 .or("age").gt(10).build();
-        ColumnCondition columnCondition = query.getCondition().get();
+        ColumnCondition condition = query.getCondition().get();
 
-        Column column = columnCondition.getColumn();
+        Column column = condition.getColumn();
         List<ColumnCondition> conditions = column.get(new TypeReference<List<ColumnCondition>>() {
         });
-        assertEquals(Condition.OR, columnCondition.getCondition());
+        assertEquals(Condition.OR, condition.getCondition());
         assertThat(conditions, Matchers.containsInAnyOrder(ColumnCondition.eq(Column.of("name", name)),
                 ColumnCondition.gt(Column.of("age", 10))));
     }

--- a/diana-core/src/main/java/org/jnosql/diana/api/Settings.java
+++ b/diana-core/src/main/java/org/jnosql/diana/api/Settings.java
@@ -36,6 +36,7 @@ public interface Settings extends Map<String, Object> {
      * @return the new {@link Settings} instance
      * @throws NullPointerException when the parameter is null
      */
+    @SafeVarargs
     static Settings of(Map<String, Object>... settings) throws NullPointerException {
         Map<String, Object> map = new HashMap<>();
         if (Stream.of(settings).anyMatch(Objects::isNull)) {

--- a/diana-core/src/main/java/org/jnosql/diana/api/reader/EnumValueReader.java
+++ b/diana-core/src/main/java/org/jnosql/diana/api/reader/EnumValueReader.java
@@ -59,8 +59,7 @@ public final class EnumValueReader implements ValueReader {
     }
 
     private <T> List<Enum> getEnumList(Class<Enum> clazz) {
-        Class<Enum> enumClass = clazz;
-        EnumSet enumSet = EnumSet.allOf(enumClass);
+        EnumSet enumSet = EnumSet.allOf(clazz);
         return new ArrayList<>(enumSet);
     }
 

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/DefaultDocumentCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/DefaultDocumentCondition.java
@@ -143,12 +143,12 @@ class DefaultDocumentCondition implements DocumentCondition {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || !DocumentCondition.class.isAssignableFrom(o.getClass())) {
             return false;
         }
-        DefaultDocumentCondition that = (DefaultDocumentCondition) o;
-        return Objects.equals(document, that.document) &&
-                condition == that.condition;
+        DocumentCondition that = (DocumentCondition) o;
+        return Objects.equals(document, that.getDocument()) &&
+                condition == that.getCondition();
     }
 
     @Override

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/Document.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/Document.java
@@ -71,8 +71,8 @@ public interface Document extends Serializable {
      * @param clazz {@link org.jnosql.diana.api.Value#get(Class)}
      * @param <T> {@link org.jnosql.diana.api.Value#get(Class)}
      * @return {@link org.jnosql.diana.api.Value#get(Class)}
-     * @throws NullPointerException {@link org.jnosql.diana.api.Value#get(Class)}
-     * @throws UnsupportedOperationException {@link org.jnosql.diana.api.Value#get(Class)}
+     * @throws NullPointerException see {@link org.jnosql.diana.api.Value#get(Class)}
+     * @throws UnsupportedOperationException see {@link org.jnosql.diana.api.Value#get(Class)}
      */
     <T> T get(Class<T> clazz) throws NullPointerException, UnsupportedOperationException;
 
@@ -81,8 +81,8 @@ public interface Document extends Serializable {
      * @param typeSupplier {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
      * @param <T> {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
      * @return {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
-     * @throws NullPointerException {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
-     * @throws UnsupportedOperationException {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
+     * @throws NullPointerException see {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
+     * @throws UnsupportedOperationException see {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
      */
     <T> T get(TypeSupplier<T> typeSupplier) throws NullPointerException, UnsupportedOperationException;
 

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/DocumentEntity.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/DocumentEntity.java
@@ -180,7 +180,7 @@ public interface DocumentEntity extends Serializable {
     /**
      * Returns true if this DocumentEntity contains a document whose the name is informed
      *
-     * @param documentName
+     * @param documentName the document name
      * @return true if find a document and otherwise false
      */
     boolean contains(String documentName);

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilder.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilder.java
@@ -16,23 +16,33 @@
  */
 package org.jnosql.diana.api.document.query;
 
+import org.jnosql.diana.api.document.Document;
 import org.jnosql.diana.api.document.DocumentCondition;
 import org.jnosql.diana.api.document.DocumentDeleteQuery;
 
 import java.util.List;
 
+import static java.util.Arrays.asList;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 /**
  * The default implementation to Delete query
  */
-class DefaultDeleteQueryBuilder implements DocumentDelete, DocumentDeleteFrom, DocumentDeleteWhere {
+class DefaultDeleteQueryBuilder implements DocumentDelete, DocumentDeleteFrom,
+        DocumentDeleteWhere, DocumentDeleteWhereName, DocumentDeleteNotCondition {
 
     private String documentCollection;
 
     private DocumentCondition condition;
 
     private final List<String> documents;
+
+    private String name;
+
+    private boolean negate;
+
+    private boolean and;
 
     DefaultDeleteQueryBuilder(List<String> documents) {
         this.documents = documents;
@@ -53,6 +63,13 @@ class DefaultDeleteQueryBuilder implements DocumentDelete, DocumentDeleteFrom, D
     }
 
     @Override
+    public DocumentDeleteWhereName where(String name) throws NullPointerException {
+        requireNonNull(name, "name is required");
+        this.name = name;
+        return this;
+    }
+
+    @Override
     public DocumentDeleteWhere and(DocumentCondition condition) throws NullPointerException {
         requireNonNull(condition, "condition is required");
         this.condition = this.condition.and(condition);
@@ -66,9 +83,107 @@ class DefaultDeleteQueryBuilder implements DocumentDelete, DocumentDeleteFrom, D
         return this;
     }
 
+    @Override
+    public DocumentDeleteNameCondition and(String name) throws NullPointerException {
+        requireNonNull(name, "name is required");
+        this.name = name;
+        this.and = true;
+        return this;
+    }
+
+    @Override
+    public DocumentDeleteNameCondition or(String name) throws NullPointerException {
+        requireNonNull(name, "name is required");
+        this.name = name;
+        this.and = false;
+        return this;
+    }
+
+
+
+    @Override
+    public DocumentDeleteNotCondition not() {
+        this.negate = true;
+        return this;
+    }
+
+    @Override
+    public <T> DocumentDeleteWhere eq(T value) throws NullPointerException {
+        requireNonNull(value, "value is required");
+        DocumentCondition newCondition = DocumentCondition.eq(Document.of(name, value));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public DocumentDeleteWhere like(String value) throws NullPointerException {
+        requireNonNull(value, "value is required");
+        DocumentCondition newCondition = DocumentCondition.like(Document.of(name, value));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public DocumentDeleteWhere gt(Number value) throws NullPointerException {
+        requireNonNull(value, "value is required");
+        DocumentCondition newCondition = DocumentCondition.gt(Document.of(name, value));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public DocumentDeleteWhere gte(Number value) throws NullPointerException {
+        requireNonNull(value, "value is required");
+        DocumentCondition newCondition = DocumentCondition.gte(Document.of(name, value));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public DocumentDeleteWhere lt(Number value) throws NullPointerException {
+        requireNonNull(value, "value is required");
+        DocumentCondition newCondition = DocumentCondition.lt(Document.of(name, value));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public DocumentDeleteWhere lte(Number value) throws NullPointerException {
+        requireNonNull(value, "value is required");
+        DocumentCondition newCondition = DocumentCondition.lte(Document.of(name, value));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public DocumentDeleteWhere between(Number valueA, Number valueB) throws NullPointerException {
+        requireNonNull(valueA, "valueA is required");
+        requireNonNull(valueB, "valueB is required");
+        DocumentCondition newCondition = DocumentCondition.between(Document.of(name, asList(valueA, valueB)));
+        return appendCondition(newCondition);
+    }
+
+    @Override
+    public <T> DocumentDeleteWhere in(Iterable<T> values) throws NullPointerException {
+        requireNonNull(values, "values is required");
+        DocumentCondition newCondition = DocumentCondition.in(Document.of(name, values));
+        return this;
+    }
 
     @Override
     public DocumentDeleteQuery build() {
         return new DefaultDocumentDeleteQuery(documentCollection, condition, documents);
+    }
+
+    private DocumentDeleteWhere appendCondition(DocumentCondition newCondition) {
+        if (negate) {
+            newCondition = newCondition.negate();
+        }
+        if (nonNull(condition)) {
+            if (and) {
+                this.condition = condition.and(newCondition);
+            } else {
+                this.condition = condition.or(newCondition);
+            }
+        } else {
+            this.condition = newCondition;
+        }
+        this.negate = false;
+        this.name = null;
+        return this;
     }
 }

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDocumentDeleteQuery.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDocumentDeleteQuery.java
@@ -40,7 +40,7 @@ class DefaultDocumentDeleteQuery implements DocumentDeleteQuery {
 
     DefaultDocumentDeleteQuery(String documentCollection, DocumentCondition condition, List<String> documents) {
         this.documentCollection = documentCollection;
-        this.condition = condition;
+        this.condition = ofNullable(condition).map(ReadOnlyDocumentCondition::new).orElse(null);
         this.documents = documents;
     }
 

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDocumentQuery.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDocumentQuery.java
@@ -48,7 +48,7 @@ class DefaultDocumentQuery implements DocumentQuery {
         this.maxResult = maxResult;
         this.firstResult = firstResult;
         this.documentCollection = documentCollection;
-        this.condition = ofNullable(condition).map(ReadOnlyDocumentCondition::new).orElse(null);;
+        this.condition = ofNullable(condition).map(ReadOnlyDocumentCondition::new).orElse(null);
         this.sorts = sorts;
         this.documents = documents;
     }

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDocumentQuery.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DefaultDocumentQuery.java
@@ -48,7 +48,7 @@ class DefaultDocumentQuery implements DocumentQuery {
         this.maxResult = maxResult;
         this.firstResult = firstResult;
         this.documentCollection = documentCollection;
-        this.condition = condition;
+        this.condition = ofNullable(condition).map(ReadOnlyDocumentCondition::new).orElse(null);;
         this.sorts = sorts;
         this.documents = documents;
     }

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteFrom.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteFrom.java
@@ -35,6 +35,15 @@ public interface DocumentDeleteFrom {
     DocumentDeleteWhere where(DocumentCondition condition) throws NullPointerException;
 
     /**
+     * Starts a new condition defining the  column name
+     *
+     * @param name the column name
+     * @return a new {@link DocumentDeleteWhereName}
+     * @throws NullPointerException when name is null
+     */
+    DocumentDeleteWhereName where(String name) throws NullPointerException;
+
+    /**
      * Creates a new instance of {@link DocumentDeleteQuery}
      *
      * @return a new {@link DocumentDeleteQuery} instance

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteNameCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteNameCondition.java
@@ -1,0 +1,99 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+/**
+ * The base to delete name condition
+ */
+public interface DocumentDeleteNameCondition {
+
+    /**
+     * Creates the equals condition {@link org.jnosql.diana.api.Condition#EQUALS}
+     *
+     * @param value the value to the condition
+     * @param <T>   the type
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    <T> DocumentDeleteWhere eq(T value) throws NullPointerException;
+
+    /**
+     * Creates the like condition {@link org.jnosql.diana.api.Condition#LIKE}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentDeleteWhere like(String value) throws NullPointerException;
+
+    /**
+     * Creates the greater than condition {@link org.jnosql.diana.api.Condition#GREATER_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentDeleteWhere gt(Number value) throws NullPointerException;
+
+    /**
+     * Creates the greater equals than condition {@link org.jnosql.diana.api.Condition#GREATER_EQUALS_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentDeleteWhere gte(Number value) throws NullPointerException;
+
+    /**
+     * Creates the lesser than condition {@link org.jnosql.diana.api.Condition#LESSER_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentDeleteWhere lt(Number value) throws NullPointerException;
+
+    /**
+     * Creates the lesser equals than condition {@link org.jnosql.diana.api.Condition#LESSER_EQUALS_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentDeleteWhere lte(Number value) throws NullPointerException;
+
+    /**
+     * Creates the between condition {@link org.jnosql.diana.api.Condition#EQUALS}
+     *
+     * @param valueA the values within a given range
+     * @param valueB the values within a given range
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when either valueA or valueB are null
+     */
+    DocumentDeleteWhere between(Number valueA, Number valueB) throws NullPointerException;
+
+    /**
+     * Creates in condition {@link org.jnosql.diana.api.Condition#IN}
+     *
+     * @param values the values
+     * @param <T>    the type
+     * @return the {@link DocumentDeleteWhere}
+     * @throws NullPointerException when value is null
+     */
+    <T> DocumentDeleteWhere in(Iterable<T> values) throws NullPointerException;
+
+}

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteNotCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteNotCondition.java
@@ -1,0 +1,23 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+/**
+ * The document not condition
+ */
+public interface DocumentDeleteNotCondition extends DocumentDeleteNameCondition {
+}

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteWhere.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteWhere.java
@@ -43,6 +43,24 @@ public interface DocumentDeleteWhere {
     DocumentDeleteWhere or(DocumentCondition condition) throws NullPointerException;
 
     /**
+     * Starts a new condition in the select using {@link DocumentCondition#and(DocumentCondition)}
+     *
+     * @param name a condition to be added
+     * @return the same {@link DocumentDeleteNameCondition} with the condition appended
+     * @throws NullPointerException when condition is null
+     */
+    DocumentDeleteNameCondition and(String name) throws NullPointerException;
+
+    /**
+     * Starts a new condition in the select using {@link DocumentCondition#or(DocumentCondition)}
+     *
+     * @param name a condition to be added
+     * @return the same {@link DocumentDeleteNameCondition} with the condition appended
+     * @throws NullPointerException when condition is null
+     */
+    DocumentDeleteNameCondition or(String name) throws NullPointerException;
+
+    /**
      * Creates a new instance of {@link DocumentDeleteQuery}
      *
      * @return a new {@link DocumentDeleteQuery} instance

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteWhereName.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentDeleteWhereName.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+/**
+ * Starts the where name condition on delete query
+ */
+public interface DocumentDeleteWhereName extends DocumentDeleteNameCondition {
+
+    /**
+     * Creates the equals condition {@link org.jnosql.diana.api.Condition#NOT}
+     *
+     * @return {@link DocumentDeleteNotCondition}
+     */
+    DocumentDeleteNotCondition not();
+}

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentFrom.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentFrom.java
@@ -36,6 +36,15 @@ public interface DocumentFrom {
     DocumentWhere where(DocumentCondition condition) throws NullPointerException;
 
     /**
+     * Starts a new condition defining the  column name
+     *
+     * @param name the column name
+     * @return a new {@link DocumentWhereName}
+     * @throws NullPointerException when name is null
+     */
+    DocumentWhereName where(String name) throws NullPointerException;
+
+    /**
      * Defines the position of the first result to retrieve.
      *
      * @param start the first result to retrive

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentNameCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentNameCondition.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+/**
+ * The base to name condition
+ */
+public interface DocumentNameCondition {
+
+
+    /**
+     * Creates the equals condition {@link org.jnosql.diana.api.Condition#EQUALS}
+     *
+     * @param value the value to the condition
+     * @param <T>   the type
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    <T> DocumentWhere eq(T value) throws NullPointerException;
+
+    /**
+     * Creates the like condition {@link org.jnosql.diana.api.Condition#LIKE}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentWhere like(String value) throws NullPointerException;
+
+    /**
+     * Creates the greater than condition {@link org.jnosql.diana.api.Condition#GREATER_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentWhere gt(Number value) throws NullPointerException;
+
+    /**
+     * Creates the greater equals than condition {@link org.jnosql.diana.api.Condition#GREATER_EQUALS_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentWhere gte(Number value) throws NullPointerException;
+
+    /**
+     * Creates the lesser than condition {@link org.jnosql.diana.api.Condition#LESSER_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentWhere lt(Number value) throws NullPointerException;
+
+    /**
+     * Creates the lesser equals than condition {@link org.jnosql.diana.api.Condition#LESSER_EQUALS_THAN}
+     *
+     * @param value the value to the condition
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    DocumentWhere lte(Number value) throws NullPointerException;
+
+    /**
+     * Creates the between condition {@link org.jnosql.diana.api.Condition#EQUALS}
+     *
+     * @param valueA the values within a given range
+     * @param valueB the values within a given range
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when either valueA or valueB are null
+     */
+    DocumentWhere between(Number valueA, Number valueB) throws NullPointerException;
+
+    /**
+     * Creates in condition {@link org.jnosql.diana.api.Condition#IN}
+     * @param values the values
+     * @param <T> the type
+     * @return the {@link DocumentWhere}
+     * @throws NullPointerException when value is null
+     */
+    <T> DocumentWhere    in(Iterable<T> values) throws NullPointerException;
+}

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentNotCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentNotCondition.java
@@ -16,5 +16,8 @@
  */
 package org.jnosql.diana.api.document.query;
 
-public interface DocumentNotCondition {
+/**
+ * The column not condition
+ */
+public interface DocumentNotCondition extends DocumentNameCondition {
 }

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentNotCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentNotCondition.java
@@ -1,0 +1,20 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+public interface DocumentNotCondition {
+}

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhere.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhere.java
@@ -46,6 +46,24 @@ public interface DocumentWhere {
     DocumentWhere or(DocumentCondition condition) throws NullPointerException;
 
     /**
+     * Starts a new condition in the select using {@link DocumentCondition#and(DocumentCondition)}
+     *
+     * @param name a condition to be added
+     * @return the same {@link DocumentCondition} with the condition appended
+     * @throws NullPointerException when condition is null
+     */
+    DocumentCondition and(String name) throws NullPointerException;
+
+    /**
+     * Appends a new condition in the select using {@link DocumentCondition#or(DocumentCondition)}
+     *
+     * @param name a condition to be added
+     * @return the same {@link DocumentCondition} with the condition appended
+     * @throws NullPointerException when condition is null
+     */
+    DocumentCondition or(String name) throws NullPointerException;
+
+    /**
      * Defines the position of the first result to retrieve.
      *
      * @param start the first result to retrive

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhere.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhere.java
@@ -49,19 +49,19 @@ public interface DocumentWhere {
      * Starts a new condition in the select using {@link DocumentCondition#and(DocumentCondition)}
      *
      * @param name a condition to be added
-     * @return the same {@link DocumentCondition} with the condition appended
+     * @return the same {@link DocumentNameCondition} with the condition appended
      * @throws NullPointerException when condition is null
      */
-    DocumentCondition and(String name) throws NullPointerException;
+    DocumentNameCondition and(String name) throws NullPointerException;
 
     /**
      * Appends a new condition in the select using {@link DocumentCondition#or(DocumentCondition)}
      *
      * @param name a condition to be added
-     * @return the same {@link DocumentCondition} with the condition appended
+     * @return the same {@link DocumentNameCondition} with the condition appended
      * @throws NullPointerException when condition is null
      */
-    DocumentCondition or(String name) throws NullPointerException;
+    DocumentNameCondition or(String name) throws NullPointerException;
 
     /**
      * Defines the position of the first result to retrieve.

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhereName.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhereName.java
@@ -16,5 +16,15 @@
  */
 package org.jnosql.diana.api.document.query;
 
-public interface DocumentWhereName {
+/**
+ * Starts the where name condition
+ */
+public interface DocumentWhereName extends DocumentNameCondition  {
+
+    /**
+     * Creates the equals condition {@link org.jnosql.diana.api.Condition#NOT}
+     *
+     * @return {@link DocumentNotCondition}
+     */
+    DocumentNotCondition not();
 }

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhereName.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/DocumentWhereName.java
@@ -1,0 +1,20 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+public interface DocumentWhereName {
+}

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/ReadOnlyDocumentCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/ReadOnlyDocumentCondition.java
@@ -30,7 +30,6 @@ class ReadOnlyDocumentCondition implements DocumentCondition {
 
     ReadOnlyDocumentCondition(DocumentCondition condition) {
         this.condition = requireNonNull(condition, "condition is required");
-        ;
     }
 
     @Override

--- a/diana-document/src/main/java/org/jnosql/diana/api/document/query/ReadOnlyDocumentCondition.java
+++ b/diana-document/src/main/java/org/jnosql/diana/api/document/query/ReadOnlyDocumentCondition.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  Copyright (c) 2017 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.jnosql.diana.api.document.query;
+
+import org.jnosql.diana.api.Condition;
+import org.jnosql.diana.api.document.Document;
+import org.jnosql.diana.api.document.DocumentCondition;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+class ReadOnlyDocumentCondition implements DocumentCondition {
+
+    private final DocumentCondition condition;
+
+    ReadOnlyDocumentCondition(DocumentCondition condition) {
+        this.condition = requireNonNull(condition, "condition is required");
+        ;
+    }
+
+    @Override
+    public Document getDocument() {
+        return condition.getDocument();
+    }
+
+    @Override
+    public Condition getCondition() {
+        return condition.getCondition();
+    }
+
+    @Override
+    public DocumentCondition and(DocumentCondition condition) throws NullPointerException {
+        throw new IllegalStateException("You cannot change the status after building the query");
+    }
+
+    @Override
+    public DocumentCondition negate() {
+        throw new IllegalStateException("You cannot change the status after building the query");
+    }
+
+    @Override
+    public DocumentCondition or(DocumentCondition condition) throws NullPointerException {
+        throw new IllegalStateException("You cannot change the status after building the query");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !DocumentCondition.class.isAssignableFrom(o.getClass())) {
+            return false;
+        }
+        DocumentCondition that = (DocumentCondition) o;
+        return Objects.equals(condition, that.getCondition());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(condition);
+    }
+}

--- a/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilderTest.java
+++ b/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilderTest.java
@@ -23,7 +23,6 @@ import org.jnosql.diana.api.TypeReference;
 import org.jnosql.diana.api.document.Document;
 import org.jnosql.diana.api.document.DocumentCondition;
 import org.jnosql.diana.api.document.DocumentDeleteQuery;
-import org.jnosql.diana.api.document.DocumentQuery;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,7 +32,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.jnosql.diana.api.document.DocumentCondition.eq;
 import static org.jnosql.diana.api.document.DocumentCondition.gt;
 import static org.jnosql.diana.api.document.query.DocumentQueryBuilder.delete;
-import static org.jnosql.diana.api.document.query.DocumentQueryBuilder.select;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;

--- a/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilderTest.java
+++ b/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilderTest.java
@@ -65,7 +65,7 @@ public class DefaultDeleteQueryBuilderTest {
     @Test(expected = NullPointerException.class)
     public void shouldReturnErrorWhenWhereConditionIsNull() {
         String documentCollection = "documentCollection";
-        delete().from(documentCollection).where(null);
+        delete().from(documentCollection).where((DocumentCondition) null);
     }
 
     @Test
@@ -103,13 +103,13 @@ public class DefaultDeleteQueryBuilderTest {
     public void shouldReturnErrorWhenSelectWhereAndConditionIsNull() {
         String documentCollection = "documentCollection";
         DocumentCondition condition = eq(Document.of("name", "Ada"));
-        delete().from(documentCollection).where(condition).and(null);
+        delete().from(documentCollection).where(condition).and((DocumentCondition) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldReturnErrorWhenSelectWhereOrConditionIsNull() {
         String documentCollection = "documentCollection";
         DocumentCondition condition = eq(Document.of("name", "Ada"));
-        delete().from(documentCollection).where(condition).or(null);
+        delete().from(documentCollection).where(condition).or((DocumentCondition) null);
     }
 }

--- a/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilderTest.java
+++ b/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultDeleteQueryBuilderTest.java
@@ -17,15 +17,23 @@
 package org.jnosql.diana.api.document.query;
 
 
+import org.hamcrest.Matchers;
+import org.jnosql.diana.api.Condition;
+import org.jnosql.diana.api.TypeReference;
 import org.jnosql.diana.api.document.Document;
 import org.jnosql.diana.api.document.DocumentCondition;
 import org.jnosql.diana.api.document.DocumentDeleteQuery;
+import org.jnosql.diana.api.document.DocumentQuery;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.jnosql.diana.api.document.DocumentCondition.eq;
 import static org.jnosql.diana.api.document.DocumentCondition.gt;
 import static org.jnosql.diana.api.document.query.DocumentQueryBuilder.delete;
+import static org.jnosql.diana.api.document.query.DocumentQueryBuilder.select;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -111,5 +119,240 @@ public class DefaultDeleteQueryBuilderTest {
         String documentCollection = "documentCollection";
         DocumentCondition condition = eq(Document.of("name", "Ada"));
         delete().from(documentCollection).where(condition).or((DocumentCondition) null);
+    }
+
+    //
+    @Test
+    public void shouldSelectWhereNameEq() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").eq(name).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.EQUALS, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(name, document.get());
+
+    }
+
+    @Test
+    public void shouldSelectWhereNameLike() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").like(name).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.LIKE, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(name, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameGt() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").gt(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.GREATER_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameGte() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").gte(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.GREATER_EQUALS_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameLt() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").lt(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.LESSER_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameLte() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").lte(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.LESSER_EQUALS_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameBetween() {
+        String documentCollection = "documentCollection";
+        Number valueA = 10;
+        Number valueB = 20;
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").between(valueA, valueB).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.BETWEEN, condition.getCondition());
+        assertEquals("name", document.getName());
+        Assert.assertThat(document.get(new TypeReference<List<Number>>() {}), Matchers.contains(10, 20));
+    }
+
+    @Test
+    public void shouldSelectWhereNameNot() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").not().eq(name).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document column = condition.getDocument();
+        DocumentCondition negate = column.get(DocumentCondition.class);
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.NOT, condition.getCondition());
+        assertEquals(Condition.EQUALS, negate.getCondition());
+        assertEquals("name", negate.getDocument().getName());
+        assertEquals(name, negate.getDocument().get());
+    }
+
+
+    @Test
+    public void shouldSelectWhereNameAnd() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").eq(name).and("age")
+                .gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.AND, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+    @Test
+    public void shouldSelectWhereNameOr() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").eq(name)
+                .or("age").gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.OR, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+
+    @Test
+    public void shouldSelectWhereNameAnd2() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").eq(name)
+                .and(DocumentCondition.gt(Document.of("age", 10))).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.AND, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+    @Test
+    public void shouldSelectWhereNameOr2() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection).where("name").eq(name)
+                .or(DocumentCondition.gt(Document.of("age", 10))).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.OR, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+
+    @Test
+    public void shouldSelectWhereNameAnd3() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+
+        DocumentDeleteQuery query = delete().from(documentCollection)
+                .where(DocumentCondition.eq(Document.of("name", name))
+        ).and("age").gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.AND, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+    @Test
+    public void shouldSelectWhereNameOr3() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentDeleteQuery query = delete().from(documentCollection)
+                .where(DocumentCondition.eq(Document.of("name", name)))
+                .or("age").gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.OR, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
     }
 }

--- a/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultSelectQueryBuilderTest.java
+++ b/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultSelectQueryBuilderTest.java
@@ -16,11 +16,17 @@
  */
 package org.jnosql.diana.api.document.query;
 
+import org.hamcrest.Matchers;
+import org.jnosql.diana.api.Condition;
 import org.jnosql.diana.api.Sort;
+import org.jnosql.diana.api.TypeReference;
 import org.jnosql.diana.api.document.Document;
 import org.jnosql.diana.api.document.DocumentCondition;
 import org.jnosql.diana.api.document.DocumentQuery;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -147,5 +153,236 @@ public class DefaultSelectQueryBuilderTest {
         assertFalse(query.getCondition().isPresent());
         assertEquals(documentCollection, query.getDocumentCollection());
         assertEquals(10L, query.getFirstResult());
+    }
+
+    @Test
+    public void shouldSelectWhereNameEq() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where("name").eq(name).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.EQUALS, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(name, document.get());
+
+    }
+
+    @Test
+    public void shouldSelectWhereNameLike() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where("name").like(name).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.LIKE, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(name, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameGt() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentQuery query = select().from(documentCollection).where("name").gt(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.GREATER_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameGte() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentQuery query = select().from(documentCollection).where("name").gte(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.GREATER_EQUALS_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameLt() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentQuery query = select().from(documentCollection).where("name").lt(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.LESSER_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameLte() {
+        String documentCollection = "documentCollection";
+        Number value = 10;
+        DocumentQuery query = select().from(documentCollection).where("name").lte(value).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.LESSER_EQUALS_THAN, condition.getCondition());
+        assertEquals("name", document.getName());
+        assertEquals(value, document.get());
+    }
+
+    @Test
+    public void shouldSelectWhereNameBetween() {
+        String documentCollection = "documentCollection";
+        Number valueA = 10;
+        Number valueB = 20;
+        DocumentQuery query = select().from(documentCollection).where("name").between(valueA, valueB).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.BETWEEN, condition.getCondition());
+        assertEquals("name", document.getName());
+        Assert.assertThat(document.get(new TypeReference<List<Number>>() {}), Matchers.contains(10, 20));
+    }
+
+    @Test
+    public void shouldSelectWhereNameNot() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where("name").not().eq(name).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document column = condition.getDocument();
+        DocumentCondition negate = column.get(DocumentCondition.class);
+        assertTrue(query.getDocuments().isEmpty());
+        assertEquals(documentCollection, query.getDocumentCollection());
+        assertEquals(Condition.NOT, condition.getCondition());
+        assertEquals(Condition.EQUALS, negate.getCondition());
+        assertEquals("name", negate.getDocument().getName());
+        assertEquals(name, negate.getDocument().get());
+    }
+
+
+    @Test
+    public void shouldSelectWhereNameAnd() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where("name").eq(name).and("age")
+                .gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.AND, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+    @Test
+    public void shouldSelectWhereNameOr() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where("name").eq(name).or("age").gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.OR, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+
+    @Test
+    public void shouldSelectWhereNameAnd2() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+
+        DocumentQuery query = select().from(documentCollection).where("name").eq(name)
+                .and(DocumentCondition.gt(Document.of("age", 10))).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.AND, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+    @Test
+    public void shouldSelectWhereNameOr2() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where("name").eq(name)
+                .or(DocumentCondition.gt(Document.of("age", 10))).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.OR, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+
+    @Test
+    public void shouldSelectWhereNameAnd3() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+
+        DocumentQuery query = select().from(documentCollection).where(DocumentCondition.eq(Document.of("name", name))
+        ).and("age").gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.AND, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
+    }
+
+    @Test
+    public void shouldSelectWhereNameOr3() {
+        String documentCollection = "documentCollection";
+        String name = "Ada Lovelace";
+        DocumentQuery query = select().from(documentCollection).where(DocumentCondition.eq(Document.of("name", name)))
+                .or("age").gt(10).build();
+        DocumentCondition condition = query.getCondition().get();
+
+        Document document = condition.getDocument();
+        List<DocumentCondition> conditions = document.get(new TypeReference<List<DocumentCondition>>() {
+        });
+        assertEquals(Condition.OR, condition.getCondition());
+        assertThat(conditions, Matchers.containsInAnyOrder(DocumentCondition.eq(Document.of("name", name)),
+                DocumentCondition.gt(Document.of("age", 10))));
     }
 }

--- a/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultSelectQueryBuilderTest.java
+++ b/diana-document/src/test/java/org/jnosql/diana/api/document/query/DefaultSelectQueryBuilderTest.java
@@ -65,7 +65,7 @@ public class DefaultSelectQueryBuilderTest {
     @Test(expected = NullPointerException.class)
     public void shouldReturnErrorWhenWhereConditionIsNull() {
         String documentCollection = "documentCollection";
-        select().from(documentCollection).where(null);
+        select().from(documentCollection).where((DocumentCondition) null);
     }
 
     @Test
@@ -103,14 +103,14 @@ public class DefaultSelectQueryBuilderTest {
     public void shouldReturnErrorWhenSelectWhereAndConditionIsNull() {
         String documentCollection = "documentCollection";
         DocumentCondition condition = eq(Document.of("name", "Ada"));
-        select().from(documentCollection).where(condition).and(null);
+        select().from(documentCollection).where(condition).and((DocumentCondition) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldReturnErrorWhenSelectWhereOrConditionIsNull() {
         String documentCollection = "documentCollection";
         DocumentCondition condition = eq(Document.of("name", "Ada"));
-        select().from(documentCollection).where(condition).or(null);
+        select().from(documentCollection).where(condition).or((DocumentCondition) null);
     }
 
     @Test

--- a/diana-key-value/src/main/java/org/jnosql/diana/api/key/KeyValueEntity.java
+++ b/diana-key-value/src/main/java/org/jnosql/diana/api/key/KeyValueEntity.java
@@ -79,8 +79,8 @@ public interface KeyValueEntity<T> extends Serializable {
      * @param clazz {@link org.jnosql.diana.api.Value#get(Class)}
      * @param <T> {@link org.jnosql.diana.api.Value#get(Class)}
      * @return {@link org.jnosql.diana.api.Value#get(Class)}
-     * @throws NullPointerException {@link org.jnosql.diana.api.Value#get(Class)}
-     * @throws UnsupportedOperationException {@link org.jnosql.diana.api.Value#get(Class)}
+     * @throws NullPointerException see {@link org.jnosql.diana.api.Value#get(Class)}
+     * @throws UnsupportedOperationException see {@link org.jnosql.diana.api.Value#get(Class)}
      */
     <T> T get(Class<T> clazz) throws NullPointerException, UnsupportedOperationException;
 
@@ -89,8 +89,8 @@ public interface KeyValueEntity<T> extends Serializable {
      * @param typeSupplier {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
      * @param <T> {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
      * @return {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
-     * @throws NullPointerException {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
-     * @throws UnsupportedOperationException {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
+     * @throws NullPointerException see {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
+     * @throws UnsupportedOperationException see {@link org.jnosql.diana.api.Value#get(TypeSupplier)}
      */
     <T> T get(TypeSupplier<T> typeSupplier) throws NullPointerException, UnsupportedOperationException;
 


### PR DESCRIPTION
Ref: https://github.com/eclipse/jnosql-diana/issues/104

## Select queries

```java
DocumentQuery query = select().from(columnFamily).where("name").eq(name).or("age").gt(10).build();
DocumentQuery query = select().from(columnFamily).where("name").eq(name).and("age").gt(10).build();
DocumentQuery query = select().from(columnFamily).where("name").not().eq(name).build();
DocumentQuery query = select().from(columnFamily).where("salary").between(valueA, valueB).build();
```

## Delete queries

```java
DocumentDeleteQuery query = delete().from(columnFamily).where("name").eq(name).build();
DocumentDeleteQuery query = delete().from(columnFamily).where("name").not().eq(name).build();
DocumentDeleteQuery query = delete().from(columnFamily).where("name").eq(name).and("age").gt(10).build();
DocumentDeleteQuery query = delete().from(columnFamily).where("name").eq(name).or("age").gt(10).build();

```